### PR TITLE
Fix loops and memory model of the Brainfuck interpreter.

### DIFF
--- a/examples/brainfuck.rs
+++ b/examples/brainfuck.rs
@@ -7,22 +7,26 @@ jit!{ fn eval(jc: hj::JitContext, program: String) -> Result<(), ()> = eval_impl
 fn eval_impl(_jc: hj::JitContext, program: String) -> Result<(), ()> {
     let prog = program.as_bytes();
     let mut pc : usize = 0;
-    let mut val : u8 = 0;
-    let mut mem : Vec<u8> = Vec::with_capacity(256);
-    mem.resize(256, 0);
+    let mut ptr : usize = 0;
+    let mut mem : Vec<u8> = vec![0];
     loop {
         if pc >= prog.len() {
             return Ok(());
         }
         match prog[pc] {
-            b'>' => { val += 1; }
-            b'<' => { val -= 1; }
-            b'-' => { mem[val as usize] -= 1; }
-            b'+' => { mem[val as usize] += 1; }
+            b'>' => {
+                ptr += 1;
+                if ptr >= mem.len() {
+                    mem.push(0);
+                }
+            }
+            b'<' => { ptr = ptr.saturating_sub(1); }
+            b'-' => { mem[ptr] = mem[ptr].wrapping_sub(1); }
+            b'+' => { mem[ptr] = mem[ptr].wrapping_add(1); }
             b'.' => { panic!("putchar: NYI"); }
             b',' => { panic!("getchar: NYI"); }
             b'[' => {
-                if val == 0 {
+                if mem[ptr] == 0 {
                     let mut iter = (pc + 1, 0);
                     loop {
                         iter = match (iter, prog[iter.0]) {
@@ -35,6 +39,7 @@ fn eval_impl(_jc: hj::JitContext, program: String) -> Result<(), ()> {
                             ((p, d), _) => (p + 1, d)
                         }
                     }
+                    continue; // skip pc increment
                 }
             }
             b']' => {
@@ -50,6 +55,7 @@ fn eval_impl(_jc: hj::JitContext, program: String) -> Result<(), ()> {
                         ((p, d), _) => (p - 1, d)
                     }
                 }
+                continue; // skip pc increment
             }
             _ => { panic!("Unknown Symbol"); }
         }


### PR DESCRIPTION
This PR fixes the issues with the Brainfuck interpreter as pointed out by @mateon1, as well as some others.

Loops should now be working properly.

The interpreter now uses a conceptually infinite array.
Moving to the left from position 0 does nothing.
Increment and decrement now wraps in the inclusive range [0-255] instead of panicking.