### PR TITLE
Lock dynasm version to 0.1.2

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.0.0"
 authors = [ "Nicolas B. Pierron <nicolas.b.pierron@nbp.name>" ]
 
 [dependencies]
-dynasm = "0.1"
-dynasmrt = "0.1"
+dynasm = "=0.1.2"
+dynasmrt = "=0.1.2"
 serde = "1.0"
 serde_derive = "1.0"
 bincode = "0.8"


### PR DESCRIPTION
This version should work with the forked compiler

(untested)